### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "notebooks",
     "name_pretty": "AI Platform Notebooks",
     "product_documentation": "https://cloud.google.com/ai-platform/notebooks/",
-    "client_documentation": "https://googleapis.dev/python/notebooks/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/notebooks/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for AI Platform Notebooks
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-notebooks.svg
    :target: https://pypi.org/project/google-cloud-notebooks/
 .. _AI Platform Notebooks: https://cloud.google.com/ai-platform/notebooks/
-.. _Client Library Documentation: https://googleapis.dev/python/notebooks/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/notebooks/latest
 .. _Product Documentation:  https://cloud.google.com/ai-platform/notebooks/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.